### PR TITLE
Fix CI lint errors and update trivy-action version

### DIFF
--- a/src/ai-farm-assistant/admin-ai-analytics.controller.ts
+++ b/src/ai-farm-assistant/admin-ai-analytics.controller.ts
@@ -22,7 +22,8 @@ export class AdminAiAnalyticsController {
   @Get('summary')
   @RequiredPermissions('read_ai_analytics')
   @ApiOperation({
-    summary: 'KPI summary — total chats, active farmers, revenue influenced, orders from Ayo, vet escalations',
+    summary:
+      'KPI summary — total chats, active farmers, revenue influenced, orders from Ayo, vet escalations',
   })
   getSummary(@Query() query: AiAnalyticsQueryDto) {
     return this.analyticsService.getSummary(query.from, query.to);
@@ -68,7 +69,9 @@ export class AdminAiAnalyticsController {
 
   @Get('top-products')
   @RequiredPermissions('read_ai_analytics')
-  @ApiOperation({ summary: 'Top products recommended by Ayo with order attribution' })
+  @ApiOperation({
+    summary: 'Top products recommended by Ayo with order attribution',
+  })
   getTopProducts(@Query() query: AiAnalyticsTopQueryDto) {
     return this.analyticsService.getTopProducts(
       query.from,
@@ -79,7 +82,9 @@ export class AdminAiAnalyticsController {
 
   @Get('health-alerts')
   @RequiredPermissions('read_ai_analytics')
-  @ApiOperation({ summary: 'Disease and health alert reports from farmer conversations' })
+  @ApiOperation({
+    summary: 'Disease and health alert reports from farmer conversations',
+  })
   getHealthAlerts(@Query() query: AiAnalyticsQueryDto) {
     return this.analyticsService.getHealthAlerts(query.from, query.to);
   }
@@ -87,8 +92,8 @@ export class AdminAiAnalyticsController {
   @Get('satisfaction')
   @RequiredPermissions('read_ai_analytics')
   @ApiOperation({ summary: 'User satisfaction metrics' })
-  getSatisfaction(@Query() query: AiAnalyticsQueryDto) {
-    return this.analyticsService.getSatisfaction(query.from, query.to);
+  getSatisfaction() {
+    return this.analyticsService.getSatisfaction();
   }
 
   @Get('bird-type-breakdown')

--- a/src/ai-farm-assistant/ai-analytics.service.ts
+++ b/src/ai-farm-assistant/ai-analytics.service.ts
@@ -387,7 +387,7 @@ export class AiAnalyticsService {
 
   // ── user satisfaction ─────────────────────────────────────────────────────
 
-  async getSatisfaction(_from?: string, _to?: string) {
+  async getSatisfaction() {
     // Satisfaction requires explicit thumbs-up / thumbs-down feedback which is
     // not yet stored. Return a zero-state so the frontend can render the widget
     // gracefully until a feedback entity is added.

--- a/src/ai-farm-assistant/ai-farm-assistant.controller.ts
+++ b/src/ai-farm-assistant/ai-farm-assistant.controller.ts
@@ -11,7 +11,12 @@ import {
   UseInterceptors,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
-import { ApiBearerAuth, ApiConsumes, ApiOperation, ApiTags } from '@nestjs/swagger';
+import {
+  ApiBearerAuth,
+  ApiConsumes,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { UserAuthGuard } from '../auth/guards/user.guard';

--- a/src/ai-farm-assistant/ai-farm-assistant.service.ts
+++ b/src/ai-farm-assistant/ai-farm-assistant.service.ts
@@ -35,7 +35,11 @@ export class AiFarmAssistantService {
     private readonly configService: ConfigService,
   ) {}
 
-  async ask(userId: string, dto: AskFarmAssistantDto, image?: Express.Multer.File) {
+  async ask(
+    userId: string,
+    dto: AskFarmAssistantDto,
+    image?: Express.Multer.File,
+  ) {
     this.ensureEnabled();
     const message = this.sanitizeMessage(dto.message);
     const requiresVetAttention = this.detectVetAttention(message);

--- a/src/ai-farm-assistant/ai-provider.service.ts
+++ b/src/ai-farm-assistant/ai-provider.service.ts
@@ -84,7 +84,9 @@ export class AiProviderService {
       ? input.products
           .map(
             (product) =>
-              `- ${product.name} (${product.category || 'Product'}) ₦${product.price}`,
+              `- ${product.name} (${product.category || 'Product'}) ₦${
+                product.price
+              }`,
           )
           .join('\n')
       : 'No matching Agrofount products were found for this message.';
@@ -98,7 +100,9 @@ export class AiProviderService {
     const imageFormat: 'jpeg' | 'png' | 'webp' | 'gif' =
       mimeToFormat[input.imageMimeType ?? ''] ?? 'jpeg';
 
-    const userContent = `Farm context: ${JSON.stringify(input.farmContext || {})}
+    const userContent = `Farm context: ${JSON.stringify(
+      input.farmContext || {},
+    )}
 
 Relevant Agrofount products:
 ${productContext}
@@ -109,7 +113,11 @@ ${input.history
   .map((message) => `${message.role}: ${message.content}`)
   .join('\n')}
 
-Farmer question: ${input.message}${input.imageBuffer ? '\n[The farmer has also attached an image for analysis. Describe what you can observe in the image and provide relevant advice.]' : ''}
+Farmer question: ${input.message}${
+      input.imageBuffer
+        ? '\n[The farmer has also attached an image for analysis. Describe what you can observe in the image and provide relevant advice.]'
+        : ''
+    }
 
 Safety precheck requires vet attention: ${input.requiresVetAttention}
 
@@ -118,15 +126,22 @@ Respond ONLY with a JSON object with keys: reply, quickReplies, requiresVetAtten
     const command = new ConverseCommand({
       modelId,
       system: [{ text: FARM_ASSISTANT_SYSTEM_INSTRUCTION }],
-      messages: [{
-        role: 'user',
-        content: input.imageBuffer
-          ? [
-              { image: { format: imageFormat, source: { bytes: new Uint8Array(input.imageBuffer) } } },
-              { text: userContent },
-            ]
-          : [{ text: userContent }],
-      }],
+      messages: [
+        {
+          role: 'user',
+          content: input.imageBuffer
+            ? [
+                {
+                  image: {
+                    format: imageFormat,
+                    source: { bytes: new Uint8Array(input.imageBuffer) },
+                  },
+                },
+                { text: userContent },
+              ]
+            : [{ text: userContent }],
+        },
+      ],
       inferenceConfig: { temperature: 0.4, maxTokens: 1024 },
     });
 

--- a/src/ai-farm-assistant/dto/ai-analytics-query.dto.ts
+++ b/src/ai-farm-assistant/dto/ai-analytics-query.dto.ts
@@ -1,4 +1,11 @@
-import { IsDateString, IsEnum, IsInt, IsOptional, Max, Min } from 'class-validator';
+import {
+  IsDateString,
+  IsEnum,
+  IsInt,
+  IsOptional,
+  Max,
+  Min,
+} from 'class-validator';
 import { Type } from 'class-transformer';
 
 export enum ChartGranularity {

--- a/src/order/order.service.ts
+++ b/src/order/order.service.ts
@@ -926,7 +926,9 @@ export class OrderService {
       );
     } catch (error) {
       this.logger.warn(
-        `Could not resume payment for order ${order.id}: ${error?.message || error}`,
+        `Could not resume payment for order ${order.id}: ${
+          error?.message || error
+        }`,
       );
       return null;
     }


### PR DESCRIPTION
Resolve 21 prettier formatting violations across the AI farm assistant module and order service. Remove unused _from/_to params from the satisfaction stub. Bump aquasecurity/trivy-action from the non-existent 0.28.0 to v0.36.0.