### PR TITLE
Force multer@2.2.0 and ws@8.21.0 via npm overrides to resolve high se…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15192,9 +15192,9 @@
       }
     },
     "node_modules/multer": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
-      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==",
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",
@@ -19325,9 +19325,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -115,5 +115,9 @@
     "setupFiles": [
       "<rootDir>/polyfills/node-buffer.ts"
     ]
+  },
+  "overrides": {
+    "multer": "^2.2.0",
+    "ws": "^8.21.0"
   }
 }


### PR DESCRIPTION
…verity CVEs

GHSA-72gw-mp4g-v24j and GHSA-3p4h-7m6x-2hcm (multer DoS) resolved by overriding to 2.2.0. GHSA-96hv-2xvq-fx4p (ws memory exhaustion) resolved by overriding to 8.21.0. npm audit --omit=dev --audit-level=high now passes.