### PR TITLE
Update AWS GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/template.yaml
+++ b/.github/workflows/template.yaml
@@ -111,7 +111,7 @@ jobs:
         run: npm audit --omit=dev --audit-level=high
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: 'arn:aws:iam::864899834894:role/github-cicd-pipeline'
           role-session-name: samplerolesession
@@ -119,7 +119,7 @@ jobs:
 
       - name: Log in to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Build, tag, and push Docker image to ECR
         id: build-image
@@ -149,14 +149,14 @@ jobs:
 
       - name: Fill in the new image ID in the Amazon ECS task definition
         id: task-def
-        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        uses: aws-actions/amazon-ecs-render-task-definition@v1.8.5
         with:
           task-definition: ${{ inputs.task-def }}
           container-name: ${{ inputs.container-name }}
           image: ${{ steps.build-image.outputs.image }}
 
       - name: Deploy Amazon ECS task definition
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
         with:
           task-definition: ${{ steps.task-def.outputs.task-definition }}
           service: ${{ inputs.service }}


### PR DESCRIPTION
configure-aws-credentials v4→v6, amazon-ecr-login v1→v2, amazon-ecs-deploy-task-definition v1→v2, and pin
amazon-ecs-render-task-definition to v1.8.5. The v4 OIDC action was built for Node 20 and fails OIDC token exchange on the Node 24 runner that GitHub now defaults to.