### PR TITLE
Upgrade Alpine packages in production image to fix Trivy HIGH/CRITICA…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ WORKDIR /app
 
 ENV NODE_ENV=production
 
-RUN apk add --no-cache dumb-init
+RUN apk upgrade --no-cache && apk add --no-cache dumb-init
 
 # Copy only package files first
 COPY package*.json ./


### PR DESCRIPTION
…L CVEs

apk upgrade --no-cache pulls the latest patched versions of all base Alpine packages at build time, resolving the 15 vulnerabilities reported by Trivy against the node:24-alpine base image.