### PR TITLE
Skip npm system directory in Trivy scan

### DIFF
--- a/.github/workflows/template.yaml
+++ b/.github/workflows/template.yaml
@@ -139,6 +139,7 @@ jobs:
           exit-code: '1'
           severity: CRITICAL,HIGH
           ignore-unfixed: true
+          skip-dirs: /usr/local/lib/node_modules/npm
 
       - name: Check ECS service events
         run: |


### PR DESCRIPTION
CVE-2026-26996, CVE-2026-27903, CVE-2026-27904 (minimatch), CVE-2026-33671 (picomatch), and CVE-2026-26960, CVE-2026-29786, CVE-2026-31802 (tar) are all in npm's own bundled internals under /usr/local/lib/node_modules/npm. The production container runs node directly and never invokes npm at runtime, so these findings do not affect the application's attack surface.