### PR TITLE
Trigger production deployment automatically on push to main

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - dev
+      - main
   workflow_dispatch:
     inputs:
       deploy_production:
@@ -26,9 +27,8 @@ jobs:
 
   deploy-prod:
     if: >-
-      github.event_name == 'workflow_dispatch' &&
-      github.ref == 'refs/heads/main' &&
-      inputs.deploy_production
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && inputs.deploy_production)
     uses: ./.github/workflows/template.yaml
     with:
       environment: prod


### PR DESCRIPTION
Previously production only deployed via manual workflow_dispatch. Now any push (or merged PR) to main automatically runs deploy-prod, keeping parity with how dev deploys on push to dev. Manual workflow_dispatch to main still works as a fallback.