### PR TITLE
Move @aws-sdk/client-bedrock-runtime to production dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
+        "@aws-sdk/client-bedrock-runtime": "^3.864.0",
         "@aws-sdk/client-s3": "^3.1068.0",
         "@aws-sdk/lib-storage": "^3.1068.0",
         "@aws-sdk/s3-request-presigner": "^3.1068.0",
@@ -49,7 +50,6 @@
         "typeorm-extension": "^3.9.0"
       },
       "devDependencies": {
-        "@aws-sdk/client-bedrock-runtime": "^3.864.0",
         "@aws-sdk/client-dynamodb": "^3.864.0",
         "@aws-sdk/client-lex-runtime-v2": "^3.864.0",
         "@aws-sdk/util-dynamodb": "^3.864.0",
@@ -496,7 +496,6 @@
       "version": "3.864.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.864.0.tgz",
       "integrity": "sha512-QLfNx/8ke3cJ6KgzwuTe+Uvh6IGPgs1yLXh7N9bWLQj89Zdbgkw7iYqkZaJNV1HffTdV2Rs0q9nnkKf83eUT2w==",
-      "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -558,7 +557,6 @@
       "version": "3.864.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.864.0.tgz",
       "integrity": "sha512-THiOp0OpQROEKZ6IdDCDNNh3qnNn/kFFaTSOiugDpgcE5QdsOxh1/RXq7LmHpTJum3cmnFf8jG59PHcz9Tjnlw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -608,7 +606,6 @@
       "version": "3.864.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.864.0.tgz",
       "integrity": "sha512-LFUREbobleHEln+Zf7IG83lAZwvHZG0stI7UU0CtwyuhQy5Yx0rKksHNOCmlM7MpTEbSCfntEhYi3jUaY5e5lg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.862.0",
@@ -635,7 +632,6 @@
       "version": "3.864.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.864.0.tgz",
       "integrity": "sha512-StJPOI2Rt8UE6lYjXUpg6tqSZaM72xg46ljPg8kIevtBAAfdtq9K20qT/kSliWGIBocMFAv0g2mC0hAa+ECyvg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "3.864.0",
@@ -652,7 +648,6 @@
       "version": "3.864.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.864.0.tgz",
       "integrity": "sha512-E/RFVxGTuGnuD+9pFPH2j4l6HvrXzPhmpL8H8nOoJUosjx7d4v93GJMbbl1v/fkDLqW9qN4Jx2cI6PAjohA6OA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "3.864.0",
@@ -674,7 +669,6 @@
       "version": "3.864.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.864.0.tgz",
       "integrity": "sha512-PlxrijguR1gxyPd5EYam6OfWLarj2MJGf07DvCx9MAuQkw77HBnsu6+XbV8fQriFuoJVTBLn9ROhMr/ROAYfUg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "3.864.0",
@@ -699,7 +693,6 @@
       "version": "3.864.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.864.0.tgz",
       "integrity": "sha512-2BEymFeXURS+4jE9tP3vahPwbYRl0/1MVaFZcijj6pq+nf5EPGvkFillbdBRdc98ZI2NedZgSKu3gfZXgYdUhQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.864.0",
@@ -723,7 +716,6 @@
       "version": "3.864.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.864.0.tgz",
       "integrity": "sha512-Zxnn1hxhq7EOqXhVYgkF4rI9MnaO3+6bSg/tErnBQ3F8kDpA7CFU24G1YxwaJXp2X4aX3LwthefmSJHwcVP/2g==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "3.864.0",
@@ -741,7 +733,6 @@
       "version": "3.864.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.864.0.tgz",
       "integrity": "sha512-UPyPNQbxDwHVGmgWdGg9/9yvzuedRQVF5jtMkmP565YX9pKZ8wYAcXhcYdNPWFvH0GYdB0crKOmvib+bmCuwkw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-sso": "3.864.0",
@@ -761,7 +752,6 @@
       "version": "3.864.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.864.0.tgz",
       "integrity": "sha512-nNcjPN4SYg8drLwqK0vgVeSvxeGQiD0FxOaT38mV2H8cu0C5NzpvA+14Xy+W6vT84dxgmJYKk71Cr5QL2Oz+rA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "3.864.0",
@@ -779,7 +769,6 @@
       "version": "3.862.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.862.0.tgz",
       "integrity": "sha512-jDje8dCFeFHfuCAxMDXBs8hy8q9NCTlyK4ThyyfAj3U4Pixly2mmzY2u7b7AyGhWsjJNx8uhTjlYq5zkQPQCYw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.862.0",
@@ -795,7 +784,6 @@
       "version": "3.862.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.862.0.tgz",
       "integrity": "sha512-N/bXSJznNBR/i7Ofmf9+gM6dx/SPBK09ZWLKsW5iQjqKxAKn/2DozlnE54uiEs1saHZWoNDRg69Ww4XYYSlG1Q==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.862.0",
@@ -810,7 +798,6 @@
       "version": "3.862.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.862.0.tgz",
       "integrity": "sha512-KVoo3IOzEkTq97YKM4uxZcYFSNnMkhW/qj22csofLegZi5fk90ztUnnaeKfaEJHfHp/tm1Y3uSoOXH45s++kKQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.862.0",
@@ -826,7 +813,6 @@
       "version": "3.864.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.864.0.tgz",
       "integrity": "sha512-wrddonw4EyLNSNBrApzEhpSrDwJiNfjxDm5E+bn8n32BbAojXASH8W8jNpxz/jMgNkkJNxCfyqybGKzBX0OhbQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "3.864.0",
@@ -845,7 +831,6 @@
       "version": "3.864.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.864.0.tgz",
       "integrity": "sha512-H1C+NjSmz2y8Tbgh7Yy89J20yD/hVyk15hNoZDbCYkXg0M358KS7KVIEYs8E2aPOCr1sK3HBE819D/yvdMgokA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -895,7 +880,6 @@
       "version": "3.862.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.862.0.tgz",
       "integrity": "sha512-VisR+/HuVFICrBPY+q9novEiE4b3mvDofWqyvmxHcWM7HumTz9ZQSuEtnlB/92GVM3KDUrR9EmBHNRrfXYZkcQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.862.0",
@@ -913,7 +897,6 @@
       "version": "3.864.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.864.0.tgz",
       "integrity": "sha512-gTc2QHOBo05SCwVA65dUtnJC6QERvFaPiuppGDSxoF7O5AQNK0UR/kMSenwLqN8b5E1oLYvQTv3C1idJLRX0cg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "3.864.0",
@@ -932,7 +915,6 @@
       "version": "3.862.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.862.0.tgz",
       "integrity": "sha512-eCZuScdE9MWWkHGM2BJxm726MCmWk/dlHjOKvkM0sN1zxBellBMw5JohNss1Z8/TUmnW2gb9XHTOiHuGjOdksA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.862.0",
@@ -949,7 +931,6 @@
       "version": "3.862.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.862.0.tgz",
       "integrity": "sha512-BmPTlm0r9/10MMr5ND9E92r8KMZbq5ltYXYpVcUbAsnB1RJ8ASJuRoLne5F7mB3YMx0FJoOTuSq7LdQM3LgW3Q==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.862.0",
@@ -962,7 +943,6 @@
       "version": "3.864.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.864.0.tgz",
       "integrity": "sha512-d+FjUm2eJEpP+FRpVR3z6KzMdx1qwxEYDz8jzNKwxYLBBquaBaP/wfoMtMQKAcbrR7aT9FZVZF7zDgzNxUvQlQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/middleware-user-agent": "3.864.0",
@@ -987,7 +967,6 @@
       "version": "3.862.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.862.0.tgz",
       "integrity": "sha512-6Ed0kmC1NMbuFTEgNmamAUU1h5gShgxL1hBVLbEzUa3trX5aJBz1vU4bXaBTvOYUAnOHtiy1Ml4AMStd6hJnFA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.2",
@@ -1001,7 +980,6 @@
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.3.tgz",
       "integrity": "sha512-fCJd2ZR7D22XhDY0l+92pUag/7je2BztPRQ01gU5bMChcyI0rlly7QFibnYHzcxDvccMjlpM/Q1ev8ceRIb48w==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.2",
@@ -1015,7 +993,6 @@
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.1.3.tgz",
       "integrity": "sha512-mARDSXSEgllNzMw6N+mC+r1AQlEBO3meEAkR/UlfAgnMzJUB3goRBWgip1EAMG99wh36MDqzo86SfIX5Y+VEaw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^4.0.0",
@@ -1035,7 +1012,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
       "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^4.0.0",
@@ -2947,7 +2923,6 @@
       "version": "3.862.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.862.0.tgz",
       "integrity": "sha512-jbGpv5UaGPz5MNZxSVa4nujQUR7uQXnPIxzQc03ul1Ehd7Eh1x0egh9Nx40HFVOuuXWr864qVZQQSWGEOR2gnA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.862.0",
@@ -2963,7 +2938,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.0.5.tgz",
       "integrity": "sha512-miEUN+nz2UTNoRYRhRqVTJCx7jMeILdAurStT2XoS+mhokkmz1xAPp95DFW9Gxt4iF2VBqpeF9HbTQ3kY1viOA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
@@ -3041,7 +3015,6 @@
       "version": "3.862.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.862.0.tgz",
       "integrity": "sha512-PlnUSgqBHXttxGc1MaXGz02o6H4C9dxv+RS+1G7msUlcD4rl4fS1AkjOAHLCfzKvZdcEHygeN8levK6hZOCENg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.862.0",
@@ -3057,7 +3030,6 @@
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.3.tgz",
       "integrity": "sha512-fCJd2ZR7D22XhDY0l+92pUag/7je2BztPRQ01gU5bMChcyI0rlly7QFibnYHzcxDvccMjlpM/Q1ev8ceRIb48w==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.2",
@@ -3290,7 +3262,6 @@
       "version": "3.862.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.862.0.tgz",
       "integrity": "sha512-EfdLqToN5VHbqvD9iBgs/fxYsHxsgJeFnTIv1XarRf3XYqO9UAf+PPSTTUxAKeqD65ZrKFwfmLwjXOwVT86zcw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.862.0",
@@ -3312,7 +3283,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.0.5.tgz",
       "integrity": "sha512-miEUN+nz2UTNoRYRhRqVTJCx7jMeILdAurStT2XoS+mhokkmz1xAPp95DFW9Gxt4iF2VBqpeF9HbTQ3kY1viOA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
@@ -3328,7 +3298,6 @@
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.3.tgz",
       "integrity": "sha512-fCJd2ZR7D22XhDY0l+92pUag/7je2BztPRQ01gU5bMChcyI0rlly7QFibnYHzcxDvccMjlpM/Q1ev8ceRIb48w==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.2",
@@ -3342,7 +3311,6 @@
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.1.3.tgz",
       "integrity": "sha512-mARDSXSEgllNzMw6N+mC+r1AQlEBO3meEAkR/UlfAgnMzJUB3goRBWgip1EAMG99wh36MDqzo86SfIX5Y+VEaw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^4.0.0",
@@ -3362,7 +3330,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
       "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^4.0.0",
@@ -3677,7 +3644,6 @@
       "version": "3.862.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.862.0.tgz",
       "integrity": "sha512-4kd2PYUMA/fAnIcVVwBIDCa2KCuUPrS3ELgScLjBaESP0NN+K163m40U5RbzNec/elOcJHR8lEThzzSb7vXH6w==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.862.0",
@@ -7418,7 +7384,6 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.1.5.tgz",
       "integrity": "sha512-viuHMxBAqydkB0AfWwHIdwf/PRH2z5KHGUzqyRtS/Wv+n3IHI993Sk76VCA7dD/+GzgGOmlJDITfPcJC1nIVIw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.1.4",
@@ -7547,7 +7512,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.0.5.tgz",
       "integrity": "sha512-LCUQUVTbM6HFKzImYlSB9w4xafZmpdmZsOh9rIl7riPC3osCgGFVP+wwvYVw6pXda9PPT9TcEZxaq3XE81EdJQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/eventstream-serde-universal": "^4.0.5",
@@ -7562,7 +7526,6 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.1.3.tgz",
       "integrity": "sha512-yTTzw2jZjn/MbHu1pURbHdpjGbCuMHWncNBpJnQAPxOVnFUAbSIUSwafiphVDjNV93TdBJWmeVAds7yl5QCkcA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.2",
@@ -7576,7 +7539,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.0.5.tgz",
       "integrity": "sha512-lGS10urI4CNzz6YlTe5EYG0YOpsSp3ra8MXyco4aqSkQDuyZPIw2hcaxDU82OUVtK7UY9hrSvgWtpsW5D4rb4g==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/eventstream-serde-universal": "^4.0.5",
@@ -7591,7 +7553,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.0.5.tgz",
       "integrity": "sha512-JFnmu4SU36YYw3DIBVao3FsJh4Uw65vVDIqlWT4LzR6gXA0F3KP0IXFKKJrhaVzCBhAuMsrUUaT5I+/4ZhF7aw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/eventstream-codec": "^4.0.5",
@@ -7606,7 +7567,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.0.5.tgz",
       "integrity": "sha512-miEUN+nz2UTNoRYRhRqVTJCx7jMeILdAurStT2XoS+mhokkmz1xAPp95DFW9Gxt4iF2VBqpeF9HbTQ3kY1viOA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
@@ -7636,7 +7596,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.5.tgz",
       "integrity": "sha512-cv1HHkKhpyRb6ahD8Vcfb2Hgz67vNIXEp2vnhzfxLFGRukLCNEA5QdsorbUEzXma1Rco0u3rx5VTqbM06GcZqQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.2",
@@ -7652,7 +7611,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
       "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^4.0.0",
@@ -7666,7 +7624,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.5.tgz",
       "integrity": "sha512-IVnb78Qtf7EJpoEVo7qJ8BEXQwgC4n3igeJNNKEj/MLYtapnx8A67Zt/J3RXAj2xSO1910zk0LdFiygSemuLow==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.2",
@@ -7680,7 +7637,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
       "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -7693,7 +7649,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.5.tgz",
       "integrity": "sha512-l1jlNZoYzoCC7p0zCtBDE5OBXZ95yMKlRlftooE5jPWQn4YBPLgsp+oeHp7iMHaTGoUdFqmHOPa8c9G3gBsRpQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^5.1.3",
@@ -7708,7 +7663,6 @@
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.3.tgz",
       "integrity": "sha512-fCJd2ZR7D22XhDY0l+92pUag/7je2BztPRQ01gU5bMChcyI0rlly7QFibnYHzcxDvccMjlpM/Q1ev8ceRIb48w==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.2",
@@ -7722,7 +7676,6 @@
       "version": "4.1.19",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.19.tgz",
       "integrity": "sha512-EAlEPncqo03siNZJ9Tm6adKCQ+sw5fNU8ncxWwaH0zTCwMPsgmERTi6CEKaermZdgJb+4Yvh0NFm36HeO4PGgQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.9.0",
@@ -7742,7 +7695,6 @@
       "version": "4.1.20",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.20.tgz",
       "integrity": "sha512-T3maNEm3Masae99eFdx1Q7PIqBBEVOvRd5hralqKZNeIivnoGNx5OFtI3DiZ5gCjUkl0mNondlzSXeVxkinh7Q==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.1.4",
@@ -7764,7 +7716,6 @@
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.3.tgz",
       "integrity": "sha512-fCJd2ZR7D22XhDY0l+92pUag/7je2BztPRQ01gU5bMChcyI0rlly7QFibnYHzcxDvccMjlpM/Q1ev8ceRIb48w==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.2",
@@ -7778,7 +7729,6 @@
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.9.tgz",
       "integrity": "sha512-uAFFR4dpeoJPGz8x9mhxp+RPjo5wW0QEEIPPPbLXiRRWeCATf/Km3gKIVR5vaP8bN1kgsPhcEeh+IZvUlBv6Xg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^5.1.3",
@@ -7793,7 +7743,6 @@
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.3.tgz",
       "integrity": "sha512-fCJd2ZR7D22XhDY0l+92pUag/7je2BztPRQ01gU5bMChcyI0rlly7QFibnYHzcxDvccMjlpM/Q1ev8ceRIb48w==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.2",
@@ -7807,7 +7756,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.5.tgz",
       "integrity": "sha512-/yoHDXZPh3ocRVyeWQFvC44u8seu3eYzZRveCMfgMOBcNKnAmOvjbL9+Cp5XKSIi9iYA9PECUuW2teDAk8T+OQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.2",
@@ -7821,7 +7769,6 @@
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.1.4.tgz",
       "integrity": "sha512-+UDQV/k42jLEPPHSn39l0Bmc4sB1xtdI9Gd47fzo/0PbXzJ7ylgaOByVjF5EeQIumkepnrJyfx86dPa9p47Y+w==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^4.0.5",
@@ -7851,7 +7798,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.5.tgz",
       "integrity": "sha512-R/bswf59T/n9ZgfgUICAZoWYKBHcsVDurAGX88zsiUtOTA/xUAPyiT+qkNCPwFn43pZqN84M4MiUsbSGQmgFIQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.2",
@@ -7894,7 +7840,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.5.tgz",
       "integrity": "sha512-NJeSCU57piZ56c+/wY+AbAw6rxCCAOZLCIniRE7wqvndqxcKKDOXzwWjrY7wGKEISfhL9gBbAaWWgHsUGedk+A==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.2",
@@ -7909,7 +7854,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.5.tgz",
       "integrity": "sha512-6SV7md2CzNG/WUeTjVe6Dj8noH32r4MnUeFKZrnVYsQxpGSIcphAanQMayi8jJLZAWm6pdM9ZXvKCpWOsIGg0w==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.2",
@@ -7923,7 +7867,6 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.7.tgz",
       "integrity": "sha512-XvRHOipqpwNhEjDf2L5gJowZEm5nsxC16pAZOeEcsygdjv9A2jdOh3YoDQvOXBGTsaJk6mNWtzWalOB9976Wlg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.2"
@@ -7936,7 +7879,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.5.tgz",
       "integrity": "sha512-YVVwehRDuehgoXdEL4r1tAAzdaDgaC9EQvhK0lEbfnbrd0bd5+CTQumbdPryX3J2shT7ZqQE+jPW4lmNBAB8JQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.2",
@@ -8041,7 +7983,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.5.0.tgz",
       "integrity": "sha512-ZSdE3vl0MuVbEwJBxSftm0J5nL/gw76xp5WF13zW9cN18MFuFXD5/LV0QD8P+sCU5bSWGyy6CTgUupE1HhOo1A==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.9.0",
@@ -8060,7 +8001,6 @@
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.3.tgz",
       "integrity": "sha512-fCJd2ZR7D22XhDY0l+92pUag/7je2BztPRQ01gU5bMChcyI0rlly7QFibnYHzcxDvccMjlpM/Q1ev8ceRIb48w==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.2",
@@ -8086,7 +8026,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.5.tgz",
       "integrity": "sha512-j+733Um7f1/DXjYhCbvNXABV53NyCRRA54C7bNEIxNPs0YjfRxeMKjjgm2jvTYrciZyCjsicHwQ6Q0ylo+NAUw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/querystring-parser": "^4.0.5",
@@ -8101,7 +8040,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.0.0.tgz",
       "integrity": "sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^4.0.0",
@@ -8116,7 +8054,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
       "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^4.0.0",
@@ -8130,7 +8067,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.0.0.tgz",
       "integrity": "sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -8143,7 +8079,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.0.0.tgz",
       "integrity": "sha512-q0iDP3VsZzqJyje8xJWEJCNIu3lktUGVoSy1KB0UWym2CL1siV3artm+u1DFYTLejpsrdGyCSWBdGNjJzfDPjg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -8156,7 +8091,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
       "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^4.0.0",
@@ -8170,7 +8104,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.0.0.tgz",
       "integrity": "sha512-L1RBVzLyfE8OXH+1hsJ8p+acNUSirQnWQ6/EgpchV88G6zGBTDPdXiiExei6Z1wR2RxYvxY/XLw6AMNCCt8H3w==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -8183,7 +8116,6 @@
       "version": "4.0.27",
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.27.tgz",
       "integrity": "sha512-i/Fu6AFT5014VJNgWxKomBJP/GB5uuOsM4iHdcmplLm8B1eAqnRItw4lT2qpdO+mf+6TFmf6dGcggGLAVMZJsQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^4.0.5",
@@ -8200,7 +8132,6 @@
       "version": "4.0.27",
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.27.tgz",
       "integrity": "sha512-3W0qClMyxl/ELqTA39aNw1N+pN0IjpXT7lPFvZ8zTxqVFP7XCpACB9QufmN4FQtd39xbgS7/Lekn7LmDa63I5w==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/config-resolver": "^4.1.5",
@@ -8219,7 +8150,6 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.7.tgz",
       "integrity": "sha512-klGBP+RpBp6V5JbrY2C/VKnHXn3d5V2YrifZbmMY8os7M6m8wdYFoO6w/fe5VkP+YVwrEktW3IWYaSQVNZJ8oQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.1.4",
@@ -8234,7 +8164,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz",
       "integrity": "sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -8247,7 +8176,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.5.tgz",
       "integrity": "sha512-N40PfqsZHRSsByGB81HhSo+uvMxEHT+9e255S53pfBw/wI6WKDI7Jw9oyu5tJTLwZzV5DsMha3ji8jk9dsHmQQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.2",
@@ -8261,7 +8189,6 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.7.tgz",
       "integrity": "sha512-TTO6rt0ppK70alZpkjwy+3nQlTiqNfoXja+qwuAchIEAIoSZW8Qyd76dvBv3I5bCpE38APafG23Y/u270NspiQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/service-error-classification": "^4.0.7",
@@ -8276,7 +8203,6 @@
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.4.tgz",
       "integrity": "sha512-vSKnvNZX2BXzl0U2RgCLOwWaAP9x/ddd/XobPK02pCbzRm5s55M53uwb1rl/Ts7RXZvdJZerPkA+en2FDghLuQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/fetch-http-handler": "^5.1.1",
@@ -8296,7 +8222,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
       "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^4.0.0",
@@ -8310,7 +8235,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz",
       "integrity": "sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -8828,7 +8752,6 @@
       "version": "9.0.8",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
       "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/validator": {
@@ -12037,7 +11960,6 @@
       "version": "5.2.5",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
       "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -18963,7 +18885,6 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
       "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@aws-sdk/client-bedrock-runtime": "^3.864.0",
     "@aws-sdk/client-s3": "^3.1068.0",
     "@aws-sdk/lib-storage": "^3.1068.0",
     "@aws-sdk/s3-request-presigner": "^3.1068.0",
@@ -64,7 +65,6 @@
     "typeorm-extension": "^3.9.0"
   },
   "devDependencies": {
-    "@aws-sdk/client-bedrock-runtime": "^3.864.0",
     "@aws-sdk/client-dynamodb": "^3.864.0",
     "@aws-sdk/client-lex-runtime-v2": "^3.864.0",
     "@aws-sdk/util-dynamodb": "^3.864.0",


### PR DESCRIPTION
The AI Farm Assistant imports BedrockRuntimeClient and ConverseCommand from this package at runtime. Having it in devDependencies meant npm ci --omit=dev in the Docker production stage skipped it, causing a module-not-found crash on startup and triggering the ECS deployment circuit breaker.