### PR TITLE
Remove AI_PROVIDER and AI_FARM_ASSISTANT_ENABLED from required produc…

### DIFF
--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -25,8 +25,6 @@ const REQUIRED_PRODUCTION_VARIABLES = [
   'AWS_BUCKET_NAME',
   'FRONTEND_URL',
   'ADMIN_FRONTEND_URL',
-  'AI_PROVIDER',
-  'AI_FARM_ASSISTANT_ENABLED',
 ] as const;
 
 export function validateEnvironment(


### PR DESCRIPTION
…tion vars

These were added to REQUIRED_PRODUCTION_VARIABLES but are not present in the production S3 env file, causing the startup validation to throw and the health check to never respond — triggering the ECS circuit breaker rollback.

The AI feature is opt-in: if not set, it defaults to disabled. Credentials are still validated when AI_FARM_ASSISTANT_ENABLED=true and AI_PROVIDER=bedrock.