### PR TITLE
Remove readonlyRootFilesystem from prod task definition

### DIFF
--- a/ecs/prod/task-definition.json
+++ b/ecs/prod/task-definition.json
@@ -15,8 +15,6 @@
         }
       ],
       "essential": true,
-      "readonlyRootFilesystem": true,
-      "user": "node",
       "healthCheck": {
         "command": [
           "CMD-SHELL",


### PR DESCRIPTION
Node.js 24 crashes silently (zero CloudWatch log output) when the container filesystem is read-only, likely due to startup cache writes. prod:43 (stable) never had this flag; removing it restores parity. The node user is already set in the Dockerfile so non-root execution is preserved without needing the task definition override.