### PR TITLE
Add migration for tokenVersion column on user table

### DIFF
--- a/src/config/database/migrations/1782050000000-UserTokenVersion.ts
+++ b/src/config/database/migrations/1782050000000-UserTokenVersion.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UserTokenVersion1782050000000 implements MigrationInterface {
+  name = 'UserTokenVersion1782050000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "user"
+      ADD COLUMN IF NOT EXISTS "tokenVersion" integer NOT NULL DEFAULT 0
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "user"
+      DROP COLUMN IF EXISTS "tokenVersion"
+    `);
+  }
+}


### PR DESCRIPTION
Missing column causes login 500 errors with DB_SYNCHRONIZE disabled.