### PR TITLE
Add migration for ai_settings and farm_assistant_feedback tables; fix…

### DIFF
--- a/src/ai-farm-assistant/entities/ai-settings.entity.ts
+++ b/src/ai-farm-assistant/entities/ai-settings.entity.ts
@@ -28,10 +28,10 @@ export class AiSettingsEntity {
   })
   monthlyBudgetUSD: number | null;
 
-  @Column({ type: 'decimal', precision: 14, scale: 6, default: 0.06 })
+  @Column({ type: 'decimal', precision: 14, scale: 6, default: '0.06' })
   costPer1MInputTokensUSD: number;
 
-  @Column({ type: 'decimal', precision: 14, scale: 6, default: 0.24 })
+  @Column({ type: 'decimal', precision: 14, scale: 6, default: '0.24' })
   costPer1MOutputTokensUSD: number;
 
   @Column({ type: 'uuid', nullable: true, default: null })

--- a/src/config/database/migrations/1782080000000-AiSettingsAndFeedback.ts
+++ b/src/config/database/migrations/1782080000000-AiSettingsAndFeedback.ts
@@ -1,0 +1,66 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AiSettingsAndFeedback1782080000000 implements MigrationInterface {
+  name = 'AiSettingsAndFeedback1782080000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "ai_settings" (
+        "id"                       integer                     NOT NULL,
+        "isActive"                 boolean                     NOT NULL DEFAULT true,
+        "provider"                 character varying(80)       NOT NULL DEFAULT 'AWS Bedrock',
+        "model"                    character varying(120)      NOT NULL DEFAULT 'amazon.nova-lite-v1:0',
+        "monthlyBudgetUSD"         numeric(14,2)                        DEFAULT NULL,
+        "costPer1MInputTokensUSD"  numeric(14,6)               NOT NULL DEFAULT '0.06',
+        "costPer1MOutputTokensUSD" numeric(14,6)               NOT NULL DEFAULT '0.24',
+        "updatedBy"                uuid                                 DEFAULT NULL,
+        "updatedAt"                TIMESTAMP                   NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_ai_settings" PRIMARY KEY ("id")
+      )
+    `);
+
+    await queryRunner.query(`
+      INSERT INTO "ai_settings" ("id") VALUES (1)
+      ON CONFLICT DO NOTHING
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "farm_assistant_feedback" (
+        "id"             uuid                  NOT NULL DEFAULT uuid_generate_v4(),
+        "conversationId" uuid                  NOT NULL,
+        "messageId"      uuid                           DEFAULT NULL,
+        "userId"         uuid                  NOT NULL,
+        "rating"         character varying(20) NOT NULL,
+        "createdAt"      TIMESTAMP             NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_farm_assistant_feedback" PRIMARY KEY ("id")
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_farm_assistant_feedback_conversation"
+        ON "farm_assistant_feedback" ("conversationId")
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_farm_assistant_feedback_user"
+        ON "farm_assistant_feedback" ("userId")
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_farm_assistant_feedback_created"
+        ON "farm_assistant_feedback" ("createdAt")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'DROP INDEX IF EXISTS "IDX_farm_assistant_feedback_created"',
+    );
+    await queryRunner.query(
+      'DROP INDEX IF EXISTS "IDX_farm_assistant_feedback_user"',
+    );
+    await queryRunner.query(
+      'DROP INDEX IF EXISTS "IDX_farm_assistant_feedback_conversation"',
+    );
+    await queryRunner.query('DROP TABLE IF EXISTS "farm_assistant_feedback"');
+    await queryRunner.query('DROP TABLE IF EXISTS "ai_settings"');
+  }
+}


### PR DESCRIPTION
… decimal default quoting

Creates ai_settings (with singleton seed row) and farm_assistant_feedback tables with their indexes. Also changes the decimal default values in AiSettingsEntity from numeric literals (0.06) to quoted strings ('0.06') so TypeORM schema:sync and migration:generate produce consistent SQL, fixing the false schema drift in CI.