### PR TITLE
Fix CI schema drift for ai_settings decimal columns

### DIFF
--- a/src/ai-farm-assistant/ai-settings.service.ts
+++ b/src/ai-farm-assistant/ai-settings.service.ts
@@ -22,7 +22,11 @@ export class AiSettingsService {
 
     if (!settings) {
       settings = await this.settingsRepository.save(
-        this.settingsRepository.create({ id: SETTINGS_ID }),
+        this.settingsRepository.create({
+          id: SETTINGS_ID,
+          costPer1MInputTokensUSD: 0.06,
+          costPer1MOutputTokensUSD: 0.24,
+        }),
       );
     }
 

--- a/src/ai-farm-assistant/entities/ai-settings.entity.ts
+++ b/src/ai-farm-assistant/entities/ai-settings.entity.ts
@@ -28,10 +28,10 @@ export class AiSettingsEntity {
   })
   monthlyBudgetUSD: number | null;
 
-  @Column({ type: 'decimal', precision: 14, scale: 6, default: '0.06' })
+  @Column({ type: 'decimal', precision: 14, scale: 6 })
   costPer1MInputTokensUSD: number;
 
-  @Column({ type: 'decimal', precision: 14, scale: 6, default: '0.24' })
+  @Column({ type: 'decimal', precision: 14, scale: 6 })
   costPer1MOutputTokensUSD: number;
 
   @Column({ type: 'uuid', nullable: true, default: null })

--- a/src/config/database/migrations/1782080000000-AiSettingsAndFeedback.ts
+++ b/src/config/database/migrations/1782080000000-AiSettingsAndFeedback.ts
@@ -11,8 +11,8 @@ export class AiSettingsAndFeedback1782080000000 implements MigrationInterface {
         "provider"                 character varying(80)       NOT NULL DEFAULT 'AWS Bedrock',
         "model"                    character varying(120)      NOT NULL DEFAULT 'amazon.nova-lite-v1:0',
         "monthlyBudgetUSD"         numeric(14,2)                        DEFAULT NULL,
-        "costPer1MInputTokensUSD"  numeric(14,6)               NOT NULL DEFAULT '0.06',
-        "costPer1MOutputTokensUSD" numeric(14,6)               NOT NULL DEFAULT '0.24',
+        "costPer1MInputTokensUSD"  numeric(14,6)               NOT NULL,
+        "costPer1MOutputTokensUSD" numeric(14,6)               NOT NULL,
         "updatedBy"                uuid                                 DEFAULT NULL,
         "updatedAt"                TIMESTAMP                   NOT NULL DEFAULT now(),
         CONSTRAINT "PK_ai_settings" PRIMARY KEY ("id")
@@ -20,7 +20,8 @@ export class AiSettingsAndFeedback1782080000000 implements MigrationInterface {
     `);
 
     await queryRunner.query(`
-      INSERT INTO "ai_settings" ("id") VALUES (1)
+      INSERT INTO "ai_settings" ("id", "costPer1MInputTokensUSD", "costPer1MOutputTokensUSD")
+      VALUES (1, 0.06, 0.24)
       ON CONFLICT DO NOTHING
     `);
 


### PR DESCRIPTION
PostgreSQL normalizes numeric defaults — DEFAULT '0.06' is stored internally as 0.06, so TypeORM migration:check always sees a mismatch for decimal columns with non-zero defaults. Remove database-level defaults from costPer1MInputTokensUSD and costPer1MOutputTokensUSD so schema:sync and entity metadata agree (both: no default). Migration INSERT now supplies explicit values (0.06, 0.24) instead of relying on column defaults. Service fallback also provides explicit values when bootstrapping the singleton row.