### PR TITLE
Match tags array default to TypeORM DB introspection

### DIFF
--- a/src/ai-platform/entities/ai-knowledge-chunk.entity.ts
+++ b/src/ai-platform/entities/ai-knowledge-chunk.entity.ts
@@ -37,7 +37,7 @@ export class AiKnowledgeChunkEntity {
   @Column({ type: 'jsonb', default: {} })
   metadata: Record<string, unknown>;
 
-  @Column({ type: 'text', array: true, default: () => 'ARRAY[]::text[]' })
+  @Column({ type: 'text', array: true, default: () => 'ARRAY[]' })
   tags: string[];
 
   @Column({ type: 'int', default: 0 })

--- a/src/ai-platform/entities/ai-knowledge-document.entity.ts
+++ b/src/ai-platform/entities/ai-knowledge-document.entity.ts
@@ -40,7 +40,7 @@ export class AiKnowledgeDocumentEntity {
   @Column({ type: 'jsonb', default: {} })
   metadata: Record<string, unknown>;
 
-  @Column({ type: 'text', array: true, default: () => 'ARRAY[]::text[]' })
+  @Column({ type: 'text', array: true, default: () => 'ARRAY[]' })
   tags: string[];
 
   @Column({ type: 'varchar', length: 80, nullable: true })


### PR DESCRIPTION
PostgreSQL stores the default as ARRAY[] (without explicit text cast), but the entity declared ARRAY[]::text[], causing migration:check to flag a false schema drift on every CI run.