### PR TITLE
Fix tags array default to match PostgreSQL introspection

### DIFF
--- a/src/ai-platform/entities/ai-knowledge-chunk.entity.ts
+++ b/src/ai-platform/entities/ai-knowledge-chunk.entity.ts
@@ -37,7 +37,7 @@ export class AiKnowledgeChunkEntity {
   @Column({ type: 'jsonb', default: {} })
   metadata: Record<string, unknown>;
 
-  @Column({ type: 'text', array: true, default: () => 'ARRAY[]' })
+  @Column({ type: 'text', array: true, default: () => "'{}'" })
   tags: string[];
 
   @Column({ type: 'int', default: 0 })

--- a/src/ai-platform/entities/ai-knowledge-document.entity.ts
+++ b/src/ai-platform/entities/ai-knowledge-document.entity.ts
@@ -40,7 +40,7 @@ export class AiKnowledgeDocumentEntity {
   @Column({ type: 'jsonb', default: {} })
   metadata: Record<string, unknown>;
 
-  @Column({ type: 'text', array: true, default: () => 'ARRAY[]' })
+  @Column({ type: 'text', array: true, default: () => "'{}'" })
   tags: string[];
 
   @Column({ type: 'varchar', length: 80, nullable: true })

--- a/src/config/database/migrations/1782290000000-FixTagsArrayDefault.ts
+++ b/src/config/database/migrations/1782290000000-FixTagsArrayDefault.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class FixTagsArrayDefault1782290000000 implements MigrationInterface {
+  name = 'FixTagsArrayDefault1782290000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "ai_knowledge_chunk" ALTER COLUMN "tags" SET DEFAULT '{}'`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "ai_knowledge_document" ALTER COLUMN "tags" SET DEFAULT '{}'`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "ai_knowledge_document" ALTER COLUMN "tags" SET DEFAULT ARRAY[]::text[]`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "ai_knowledge_chunk" ALTER COLUMN "tags" SET DEFAULT ARRAY[]::text[]`,
+    );
+  }
+}


### PR DESCRIPTION
Change DEFAULT ARRAY[]::text[] to DEFAULT '{}' on ai_knowledge_chunk and ai_knowledge_document. PostgreSQL normalizes ARRAY[]::text[] in its catalog, causing migration:check to detect false schema drift on every CI run. '{}' is the stable array literal that round-trips cleanly through pg_get_expr. Adds a migration to apply this on existing databases.