### PR TITLE
Fix supertest namespace import broken by esModuleInterop

### DIFF
--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
-import * as request from 'supertest';
+import request from 'supertest';
 import { AppModule } from './../src/app.module';
 
 describe('AppController (e2e)', () => {


### PR DESCRIPTION
esModuleInterop disallows calling namespace-style imports. Switching to a default import matches how supertest is exported and resolves the TS2349 error in the e2e pipeline.