### PR TITLE
Fix prettier formatting in MessageFailureCategory migration

### DIFF
--- a/src/config/database/migrations/1782500000000-MessageFailureCategory.ts
+++ b/src/config/database/migrations/1782500000000-MessageFailureCategory.ts
@@ -1,8 +1,6 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class MessageFailureCategory1782500000000
-  implements MigrationInterface
-{
+export class MessageFailureCategory1782500000000 implements MigrationInterface {
   name = 'MessageFailureCategory1782500000000';
 
   public async up(queryRunner: QueryRunner): Promise<void> {


### PR DESCRIPTION
CI's lint step was failing on the multi-line class declaration wrap.